### PR TITLE
 Add a variant using Ractors

### DIFF
--- a/6-concurrent-tvar-lee.rb
+++ b/6-concurrent-tvar-lee.rb
@@ -119,7 +119,7 @@ threads = 2.times.map {
         solution = solve(board, route, cost)
 
         if expansions_dir
-        Lee.draw board, solutions.values, [[cost.keys, solution]], File.join(expansions_dir, "expansion-#{route.object_id}.svg")
+          Lee.draw board, solutions.values, [[cost.keys, solution]], File.join(expansions_dir, "expansion-#{route.object_id}.svg")
         end
 
         lay depth, solution

--- a/7-ractor-tvar-lee.rb
+++ b/7-ractor-tvar-lee.rb
@@ -1,0 +1,180 @@
+# Solves a board using TVar on multiple Ractors.
+
+require 'set'
+
+require_relative 'lib/lee'
+
+board_filename, output_filename, expansions_dir, *rest = ARGV
+raise 'no input filename' unless board_filename
+raise 'too many arguments' unless rest.empty?
+
+if expansions_dir
+  system 'rm', '-rf', expansions_dir
+  Dir.mkdir expansions_dir
+end
+
+board = Lee.read_board(board_filename)
+
+obstructed = Lee::Matrix.new(board.height, board.width)
+board.pads.each do |pad|
+  obstructed[pad.y, pad.x] = 1
+end
+
+# Would be good if we could have TArray and TMatrix instead of a Matrix of TVars!
+
+depth = Lee::Matrix.new(board.height, board.width) { Thread::TVar.new(0) }
+
+def expand(board, obstructed, depth, route)
+  start_point = route.a
+  end_point = route.b
+
+  # From benchmarking - we're better of allocating a new cost-matrix each time rather than zeroing
+  cost = Lee::Matrix.new(board.height, board.width)
+  cost[start_point.y, start_point.x] = 1
+
+  wavefront = [start_point]
+
+  loop do
+    new_wavefront = []
+
+    wavefront.each do |point|
+      point_cost = cost[point.y, point.x]
+      Lee.adjacent(board, point).each do |adjacent|
+        next if obstructed[adjacent.y, adjacent.x] == 1 && adjacent != route.b
+        current_cost = cost[adjacent.y, adjacent.x]
+        new_cost = point_cost + Lee.cost(depth[adjacent.y, adjacent.x].value)
+        if current_cost == 0 || new_cost < current_cost
+          cost[adjacent.y, adjacent.x] = new_cost
+          new_wavefront.push adjacent
+        end
+      end
+    end
+
+    raise 'stuck' if new_wavefront.empty?
+    break if cost[end_point.y, end_point.x] > 0 && cost[end_point.y, end_point.x] < new_wavefront.map { |marked| cost[marked.y, marked.x] }.min
+
+    wavefront = new_wavefront
+  end
+
+  cost
+end
+
+def solve(board, route, cost)
+  start_point = route.b
+  end_point = route.a
+
+  solution = [start_point]
+
+  loop do
+    adjacent = Lee.adjacent(board, solution.last)
+    lowest_cost = adjacent
+      .reject { |a| cost[a.y, a.x].zero? }
+      .min_by { |a| cost[a.y, a.x] }
+    solution.push lowest_cost
+    break if lowest_cost == end_point
+  end
+
+  solution.reverse
+end
+
+def lay(depth, solution)
+  solution.each do |point|
+    depth[point.y, point.x].increment
+  end
+end
+
+worklist = Ractor.new do
+  loop do
+    Ractor.yield receive
+  end
+  close
+end
+
+board.routes.each do |route|
+  worklist << route
+end
+worklist.close_incoming
+
+class Counter
+  def initialize
+    @ractor = Ractor.new do
+      count = 0
+      loop do
+        count += receive
+      end
+      count
+    end
+    Ractor.make_shareable(self)
+  end
+
+  def increment
+    @ractor << 1
+  end
+
+  def count
+    @ractor.close_incoming
+    @ractor.take
+  end
+end
+
+COMMITTED = Counter.new
+ABORTED = Counter.new
+
+class Thread
+  def self.committed
+    COMMITTED.increment
+  end
+
+  def self.aborted
+    ABORTED.increment
+  end
+end
+
+solutions_ractor = Ractor.new {
+  solutions = {}
+  loop do
+    key, value = Ractor.receive
+    solutions[key] = value
+  end
+  Ractor.make_shareable(solutions)
+}
+
+N = Integer(ENV["N"] || 2)
+
+Ractor.make_shareable([board, obstructed, depth])
+
+ractors = N.times.map {
+  Ractor.new(worklist, board, obstructed, depth, solutions_ractor, expansions_dir) {
+            |worklist, board, obstructed, depth, solutions_ractor, expansions_dir|
+    loop do
+      route = worklist.take
+
+      Thread.atomically do
+        cost = expand(board, obstructed, depth, route)
+        solution = solve(board, route, cost)
+
+        if expansions_dir
+          Lee.draw board, solutions.values, [[cost.keys, solution]], File.join(expansions_dir, "expansion-#{route.object_id}.svg")
+        end
+
+        lay depth, solution
+        solutions_ractor << [route, solution]
+      end
+    end
+  }
+}
+
+ractors.each &:take
+solutions_ractor.close_incoming
+solutions = solutions_ractor.take
+
+raise 'invalid solution' unless Lee.solution_valid?(board, solutions)
+
+cost, depth = Lee.cost_solutions(board, solutions)
+puts "routes:      #{board.routes.size}"
+puts "committed:   #{COMMITTED.count}"
+puts "aborted:     #{ABORTED.count}"
+puts "cost:        #{cost}"
+puts "depth:       #{depth}"
+
+Lee.draw board, solutions.values, output_filename if output_filename

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cost:        3307
 depth:       3
 ```
 
-You'll need to use a build of the `thread_tvar` branch of MRI, with `instrument-atomically.patch` which applies cleanly on top of at least `66e45dc50c05d5030c8f9663bb159b8e2014d8ff`, in order to run the next two commands.
+You'll need to use a build of the `thread_tvar` branch from [this PR](https://github.com/ruby/ruby/pull/3652), with `instrument-atomically.patch` which applies cleanly on top of at least `66e45dc50c05d5030c8f9663bb159b8e2014d8ff`, in order to run the next two commands.
 
 ```
 % bundle exec ruby 5-sequential-tvar-lee.rb inputs/testBoard.txt testBoard.svg


### PR DESCRIPTION
It seems to work correctly, but frequently fails with N >= 4:
```
time ruby 3-sequential-lee.rb inputs/testBoard.txt
routes: 203
cost:   3304
depth:  3
ruby 3-sequential-lee.rb inputs/testBoard.txt  1.04s user 0.01s system 99% cpu 1.051 total

time N=1 ruby 7-ractor-tvar-lee.rb inputs/testBoard.txt       
<internal:ractor>:38: warning: Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.
routes:      203
committed:   203
aborted:     0
cost:        3304
depth:       3
N=1 ruby 7-ractor-tvar-lee.rb inputs/testBoard.txt  1.68s user 0.06s system 106% cpu 1.644 total

time N=2 ruby 7-ractor-tvar-lee.rb inputs/testBoard.txt
<internal:ractor>:38: warning: Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.
routes:      203
committed:   203
aborted:     66
cost:        3299
depth:       3
N=2 ruby 7-ractor-tvar-lee.rb inputs/testBoard.txt  5.63s user 2.05s system 188% cpu 4.078 total

time N=3 ruby 7-ractor-tvar-lee.rb inputs/testBoard.txt
<internal:ractor>:38: warning: Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.
routes:      203
committed:   203
aborted:     115
cost:        3291
depth:       3
N=3 ruby 7-ractor-tvar-lee.rb inputs/testBoard.txt  11.05s user 7.06s system 245% cpu 7.379 total

time N=4 ruby 7-ractor-tvar-lee.rb inputs/testBoard.txt
<internal:ractor>:38: warning: Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.
routes:      203
committed:   203
aborted:     175
cost:        3302
depth:       3
N=4 ruby 7-ractor-tvar-lee.rb inputs/testBoard.txt  15.36s user 11.31s system 310% cpu 8.576 total

time N=4 ruby 7-ractor-tvar-lee.rb inputs/testBoard.txt
<internal:ractor>:38: warning: Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.
#<Thread:0x0000561185ba7ec0 run> terminated with exception (report_on_exception is true):
/home/eregon/code/ruby-stm-lee-demo/lib/lee/adjacent.rb:5:in `point_on_board?': undefined method `x' for 0...75:Range (NoMethodError)
	from /home/eregon/code/ruby-stm-lee-demo/lib/lee/adjacent.rb:25:in `block in adjacent'
	from /home/eregon/code/ruby-stm-lee-demo/lib/lee/adjacent.rb:25:in `select'
<internal:ractor>:130:in `take': thrown by remote Ractor. (Ractor::RemoteError)
	from 7-ractor-tvar-lee.rb:167:in `each'
	from 7-ractor-tvar-lee.rb:167:in `<main>'
/home/eregon/code/ruby-stm-lee-demo/lib/lee/adjacent.rb:5:in `point_on_board?': undefined method `x' for 0...75:Range (NoMethodError)
	from /home/eregon/code/ruby-stm-lee-demo/lib/lee/adjacent.rb:25:in `block in adjacent'
	from /home/eregon/code/ruby-stm-lee-demo/lib/lee/adjacent.rb:25:in `select'
	from /home/eregon/code/ruby-stm-lee-demo/lib/lee/adjacent.rb:25:in `adjacent'
	from 7-ractor-tvar-lee.rb:42:in `block (2 levels) in expand'
	from 7-ractor-tvar-lee.rb:40:in `each'
	from 7-ractor-tvar-lee.rb:40:in `block in expand'
	from 7-ractor-tvar-lee.rb:37:in `loop'
	from 7-ractor-tvar-lee.rb:37:in `expand'
	from 7-ractor-tvar-lee.rb:153:in `block (4 levels) in <main>'
	from <internal:thread>:25:in `atomically'
	from 7-ractor-tvar-lee.rb:152:in `block (3 levels) in <main>'
	from 7-ractor-tvar-lee.rb:149:in `loop'
	from 7-ractor-tvar-lee.rb:149:in `block (2 levels) in <main>'
zsh: exit 1     N=4 ruby 7-ractor-tvar-lee.rb inputs/testBoard.txt
N=4 ruby 7-ractor-tvar-lee.rb inputs/testBoard.txt  8.50s user 5.32s system 323% cpu 4.273 total

Other, similar error:
/home/eregon/code/ruby-stm-lee-demo/lib/lee/adjacent.rb:5:in `point_on_board?': undefined method `x' for 0...75:Range (NoMethodError)
	from /home/eregon/code/ruby-stm-lee-demo/lib/lee/adjacent.rb:25:in `block in adjacent'
	from /home/eregon/code/ruby-stm-lee-demo/lib/lee/adjacent.rb:25:in `select'
	from /home/eregon/code/ruby-stm-lee-demo/lib/lee/adjacent.rb:25:in `adjacent'
	from 7-ractor-tvar-lee.rb:42:in `block (2 levels) in expand'
	from 7-ractor-tvar-lee.rb:40:in `each'
	from 7-ractor-tvar-lee.rb:40:in `block in expand'
	from 7-ractor-tvar-lee.rb:37:in `loop'
	from 7-ractor-tvar-lee.rb:37:in `expand'
	from 7-ractor-tvar-lee.rb:153:in `block (4 levels) in <main>'
	from <internal:thread>:25:in `atomically'
	from 7-ractor-tvar-lee.rb:152:in `block (3 levels) in <main>'
	from 7-ractor-tvar-lee.rb:149:in `loop'
	from 7-ractor-tvar-lee.rb:149:in `block (2 levels) in <main>'
```

Which seems a clear bug of Ractor/CRuby, because `point` should be a Point, not an Integer there.