### PR TITLE
Add missing require for Lee::Board

### DIFF
--- a/lib/lee/board.rb
+++ b/lib/lee/board.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module Lee
 
   # A point is a location on the board.


### PR DESCRIPTION
`ruby bench/sequential.rb` and ` ruby 3-sequential-lee.rb inputs/testBoard.txt` fail without this change.
It works with `bundle exec` because I guess Bundler loads `set` as a side effect.